### PR TITLE
Patch Gandrayda fight bypass

### DIFF
--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Research.json
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Research.json
@@ -2077,8 +2077,25 @@
                             }
                         },
                         "Event - Barrier": {
-                            "type": "template",
-                            "data": "Use Grapple Voltage (Lasso and Voltage)"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Use Grapple Voltage (Lasso and Voltage)"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event11",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ],
+                            },
                         }
                     }
                 }

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Research.json
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Research.json
@@ -2077,8 +2077,25 @@
                             }
                         },
                         "Event - Barrier": {
-                            "type": "template",
-                            "data": "Use Grapple Voltage (Lasso and Voltage)"
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Use Grapple Voltage (Lasso and Voltage)"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "Event11",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 }

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Research.json
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Research.json
@@ -2077,25 +2077,8 @@
                             }
                         },
                         "Event - Barrier": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Use Grapple Voltage (Lasso and Voltage)"
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "events",
-                                            "name": "Event11",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ],
-                            },
+                            "type": "template",
+                            "data": "Use Grapple Voltage (Lasso and Voltage)"
                         }
                     }
                 }

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Research.txt
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Research.txt
@@ -271,7 +271,7 @@ Extra - asset_id: 3594029436312475339
                       Fight Ghor-G
                       Combat (Intermediate) or Damage ≥ 249
   > Event - Barrier
-      Use Grapple Voltage
+      After Gandrayda and Use Grapple Voltage
 
 ----------------
 Metroid Processing


### PR DESCRIPTION
Logic is bypassing the Gandrayda fight to lower the barrier when it shouldn't be when MP3Update is enabled.

Video demonstrating that you can't interact with the panel during the fight: https://youtu.be/ag8j3SALNmo

Node path in Pirate Homeworld - Research - Proving Grounds:
Door to Transit Station 1-B ->
Room Center ->
Event - Barrier ->
Door to Proving Grounds Lift

Example seed that shows the fight being bypassed in the Playthrough:
[Corruption Randomizer - Tautology Quintet Yowl.zip](https://github.com/user-attachments/files/29167660/Corruption.Randomizer.-.Tautology.Quintet.Yowl.zip)
Snippet of the Playthrough showing the bypass (approx 1/4 of the way through):
<img width="904" height="130" alt="image" src="https://github.com/user-attachments/assets/440b0562-98cc-4926-91d1-1aab85e8ce53" />

This patch will logically require the Gandrayda fight be completed to lower the Barrier with or without MP3Update.