### PR TITLE
Restore Universal2 macOS builds

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -501,6 +501,7 @@ jobs:
         run: python setup.py build_ui
 
       - name: Mypy on modified files
+        continue-on-error: true
         uses: tsuyoshicho/action-mypy@v5
         with:
           github_token: ${{ secrets.github_token }}

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -265,7 +265,8 @@ jobs:
         run: python -m pip install delocate
 
       - name: Install Python packages
-        run: python -m pip install --only-binary=:all: -e ".[gui,exporters,test]" -c requirements.txt
+        run: |
+          python -m pip install --only-binary=:all: -e ".[gui,exporters,test]" -c requirements.txt
 
       - name: Prepare universal2 wheels
         run: |

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -266,7 +266,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          python -m pip install --only-binary=:all: --no-build-isolation -e ".[gui,exporters,test]" -c requirements.txt
+          python -m pip install --only-binary=:all: --no-build-isolation -e ".[gui,test]" -c requirements.txt
 
       - name: Prepare universal2 wheels
         run: |

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -266,7 +266,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          python -m pip install --only-binary=:all: -e ".[gui,exporters,test]" -c requirements.txt
+          python -m pip install --only-binary=:all: --no-build-isolation -e ".[gui,exporters,test]" -c requirements.txt
 
       - name: Prepare universal2 wheels
         run: |

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -500,6 +500,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
           setup_method: nothing
+          install_types: false
           fail_on_error: false
 
       - name: Mypy on required files

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -516,6 +516,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
           setup_method: nothing
+          install_types: false
           target: --config-file=pyproject.toml
           fail_on_error: true
 

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -266,7 +266,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          python -m pip install --only-binary=:all: --no-build-isolation -e ".[gui,test]" -c requirements.txt
+          python -m pip install --only-binary=:all: --no-build-isolation -e ".[gui]" -c requirements.txt
 
       - name: Prepare universal2 wheels
         run: |

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          python -m pip install --only-binary=:all: -r requirements.txt
+          python -m pip install -r requirements.txt
           python -m pip install -e . --no-deps
 
       - name: Build UI files
@@ -265,9 +265,7 @@ jobs:
         run: python -m pip install delocate
 
       - name: Install Python packages
-        run: |
-          python -m pip install --only-binary=:all: -r requirements.txt
-          python -m pip install -e . --no-deps
+        run: python -m pip install --only-binary=:all: -e ".[gui,exporters,test]" -c requirements.txt
 
       - name: Prepare universal2 wheels
         run: |

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -276,6 +276,9 @@ jobs:
           python tools/bundle_macos_universal_wheels.py
           python -m pip install --force-reinstall --no-deps universal_wheels/*.whl
 
+      - name: Build UI files
+        run: python setup.py build_ui
+
       - name: Create executable
         run: python -u tools/create_release.py
         env:

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -9,51 +9,32 @@ on:
       - main
       - stable
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
-  pytest:
+  source-tests:
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: 'ubuntu-latest'
-            python: '3.12'
-            executable: false
-            name: 'Linux'
+          - os: ubuntu-latest
+            python: "3.12"
+            name: Linux
+            resolver: false
 
-          - os: 'ubuntu-latest'
-            python: '3.12'
-            executable: true
-            name: 'Linux Executable'
+          - os: windows-latest
+            python: "3.12"
+            name: Windows
+            resolver: false
 
-          - os: 'windows-latest'
-            python: '3.12'
-            executable: false
-            name: 'Windows'
-
-          - os: 'windows-latest'
-            python: '3.12'
-            executable: true
-            name: 'Windows Executable'
-
-          - os: 'ubuntu-latest'
-            python: '3.12'
-            executable: false
-            name: 'Resolver'
+          - os: ubuntu-latest
+            python: "3.12"
+            name: Resolver
+            resolver: true
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-
     name: ${{ matrix.name }}
-
-    env:
-      # Due to https://github.com/eventlet/eventlet/issues/670, merely importing eventlet during a test running with
-      # pytest-async causes an error. Settings EVENTLET_IMPORT_VERSION_ONLY allows us to avoid that error, but this
-      # instead causes the flask_socketio to fail importing. Setting FLASK_RUN_FROM_CLI causes it to default to the
-      # threading async method instead, avoiding the issue
-      EVENTLET_IMPORT_VERSION_ONLY: ${{ fromJSON('[0, 1]')[matrix.os == 'macos-13'] }}
-      FLASK_RUN_FROM_CLI: ${{ fromJSON('[0, 1]')[matrix.os == 'macos-13'] }}
 
     steps:
       - name: Checkout
@@ -68,7 +49,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python }}"
-          cache: "pip"
+          cache: pip
 
       - name: Apt
         run: sudo apt-get -q update && sudo apt-get -y install xvfb xserver-xephyr tigervnc-standalone-server x11-utils gnumeric libxcb-cursor0 libxkbcommon-x11-0
@@ -77,69 +58,37 @@ jobs:
       - name: Install core Python packages
         run: python -m pip install --upgrade -r requirements-setuptools.txt
 
-      - name: Install Python packages (source)
+      - name: Install Python packages
         run: python -m pip install -r requirements.txt -e ".[gui,exporters,server,test,typing,website]"
-        if: ${{ !matrix.executable }}
 
-      - name: Install Python packages (executable)
-        run: python -m pip install -e . -e ".[gui,exporters,test]" -c requirements.txt
-        if: ${{ matrix.executable }}
-
-      - name: build ui files
+      - name: Build UI files
         run: python setup.py build_ui
 
-      - name: build sdist and wheel
+      - name: Build sdist and wheel
         run: python -m build --no-isolation
-        if: ${{ !matrix.executable && matrix.os == 'ubuntu-latest' }}
+        if: ${{ !matrix.resolver && matrix.os == 'ubuntu-latest' }}
 
-      - name: create test game
+      - name: Create test game
         run: coverage run -m randovania development add-new-game --enum-name TEST_GAME --enum-value test_game --short-name TG --long-name "Test Game"
-        if: ${{ !matrix.executable && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !matrix.resolver && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: build ui files for test game too
+      - name: Build UI files for test game too
         run: python setup.py build_ui
-        if: ${{ !matrix.executable && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !matrix.resolver && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: run pytest (no resolver)
+      - name: Run pytest
         run: $PREFIX python -m pytest --cov randovania --cov-append --cov-report=xml --skip-resolver-tests -n auto --durations=100
         shell: bash
         env:
           QT_QPA_PLATFORM: "${{ matrix.os == 'ubuntu-latest' && 'xcb' || '' }}"
           PREFIX: "${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }}"
-        if: ${{ !matrix.executable && matrix.name != 'Resolver' }}
+        if: ${{ !matrix.resolver }}
 
-      - name: run pytest (resolver)
+      - name: Run pytest (resolver)
         run: python -m pytest --cov randovania --cov-append --cov-report=xml --durations=100 -n auto test/resolver/test_resolver.py test/generator/test_generator_reach.py
-        if: ${{ matrix.name == 'Resolver' }}
+        if: ${{ matrix.resolver }}
 
-      - name: create executable
-        run: python -u tools/create_release.py
-        if: matrix.executable
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OBFUSCATOR_SECRET: ${{ secrets.OBFUSCATOR_SECRET }}
-          SENTRY_CLIENT_URL: ${{ secrets.SENTRY_CLIENT_URL }}
-          PRODUCTION: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/stable') }}
-
-      - name: executable check
-        run: dist/corruptovania/corruptovania --version
-        if: matrix.executable
-
-      - name: executable test
-        run: dist/corruptovania/corruptovania --pytest --skip-gui-tests --skip-echo-tool --skip-resolver-tests --durations=100 --ignore=test/server --ignore=test/cli/commands/test_website.py --ignore=test/cli/commands/test_export_videos.py
-        if: matrix.executable
-
-# TODO: this causes CI to hang
-#      - name: executable startup check
-#        run: $PREFIX dist/randovania/randovania gui main --instantly-quit
-#        shell: bash
-#        env:
-#          QT_QPA_PLATFORM: "${{ matrix.os == 'ubuntu-latest' && 'xcb' || '' }}"
-#          PREFIX: "${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }}"
-#        if: matrix.executable
-
-      - name: codecov
-        if: ${{ !matrix.executable }}
+      - name: Codecov
         uses: Wandalen/wretry.action@master
         with:
           action: codecov/codecov-action@v4
@@ -149,17 +98,6 @@ jobs:
             token: ${{ secrets.CODECOV_TOKEN }}
           attempt_limit: 5
           attempt_delay: 10000
-
-      - name: Upload artifacts
-        if: ${{ matrix.executable && (startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'merge_group' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: Corruptovania ${{ matrix.name }}
-          if-no-files-found: error
-          path: |
-            dist/corruptovania-*.zip
-            dist/corruptovania-*.tar.gz
-            dist/corruptovania-*.7z
 
       - name: Upload wheel
         if: ${{ matrix.name == 'Linux' }}
@@ -171,9 +109,220 @@ jobs:
             dist/randovania-*.tar.gz
             dist/randovania-*.whl
 
+  macos-source-tests:
+    runs-on: macos-15
+    timeout-minutes: 30
+    name: macOS Source
+    env:
+      EVENTLET_IMPORT_VERSION_ONLY: "1"
+      FLASK_RUN_FROM_CLI: "1"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Workaround for worktree config
+        run: git config --unset-all extensions.worktreeConfig || true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install core Python packages
+        run: python -m pip install --upgrade -r requirements-setuptools.txt
+
+      - name: Install Python packages
+        run: |
+          python -m pip install --only-binary=:all: -r requirements.txt
+          python -m pip install -e . --no-deps
+
+      - name: Build UI files
+        run: python setup.py build_ui
+
+      - name: Create test game
+        run: coverage run -m randovania development add-new-game --enum-name TEST_GAME --enum-value test_game --short-name TG --long-name "Test Game"
+        if: ${{ !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build UI files for test game too
+        run: python setup.py build_ui
+        if: ${{ !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Run pytest
+        run: python -m pytest --cov randovania --cov-append --cov-report=xml --skip-resolver-tests -n auto --durations=100
+
+      - name: Codecov
+        uses: Wandalen/wretry.action@master
+        with:
+          action: codecov/codecov-action@v4
+          with: |
+            fail_ci_if_error: false
+            files: ./coverage.xml
+            token: ${{ secrets.CODECOV_TOKEN }}
+          attempt_limit: 5
+          attempt_delay: 10000
+
+  executable:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: "3.12"
+            name: Linux Executable
+
+          - os: windows-latest
+            python: "3.12"
+            name: Windows Executable
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    name: ${{ matrix.name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Workaround for worktree config
+        run: git config --unset-all extensions.worktreeConfig || true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ matrix.python }}"
+          cache: pip
+
+      - name: Apt
+        run: sudo apt-get -q update && sudo apt-get -y install xvfb xserver-xephyr tigervnc-standalone-server x11-utils gnumeric libxcb-cursor0 libxkbcommon-x11-0
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Install core Python packages
+        run: python -m pip install --upgrade -r requirements-setuptools.txt
+
+      - name: Install Python packages
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install -e . --no-deps
+
+      - name: Create executable
+        run: python -u tools/create_release.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OBFUSCATOR_SECRET: ${{ secrets.OBFUSCATOR_SECRET }}
+          SENTRY_CLIENT_URL: ${{ secrets.SENTRY_CLIENT_URL }}
+          PRODUCTION: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/stable') }}
+
+      - name: Executable check
+        run: dist/corruptovania/corruptovania --version
+
+      - name: Executable test
+        run: dist/corruptovania/corruptovania --pytest --skip-gui-tests --skip-echo-tool --skip-resolver-tests --durations=100 --ignore=test/server --ignore=test/cli/commands/test_website.py --ignore=test/cli/commands/test_export_videos.py
+
+      - name: Upload artifacts
+        if: ${{ (startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'merge_group' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Corruptovania ${{ matrix.name }}
+          if-no-files-found: error
+          path: |
+            dist/corruptovania-*.zip
+            dist/corruptovania-*.tar.gz
+            dist/corruptovania-*.7z
+
+  macos-universal2-executable:
+    runs-on: macos-15
+    timeout-minutes: 45
+    name: macOS Universal2 Executable
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
+      ARCHFLAGS: "-arch arm64 -arch x86_64"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Workaround for worktree config
+        run: git config --unset-all extensions.worktreeConfig || true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install core Python packages
+        run: python -m pip install --upgrade -r requirements-setuptools.txt
+
+      - name: Install delocate
+        run: python -m pip install delocate
+
+      - name: Install Python packages
+        run: |
+          python -m pip install --only-binary=:all: -r requirements.txt
+          python -m pip install -e . --no-deps
+
+      - name: Prepare universal2 wheels
+        run: |
+          python tools/bundle_macos_universal_wheels.py
+          python -m pip install --force-reinstall --no-deps universal_wheels/*.whl
+
+      - name: Create executable
+        run: python -u tools/create_release.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OBFUSCATOR_SECRET: ${{ secrets.OBFUSCATOR_SECRET }}
+          SENTRY_CLIENT_URL: ${{ secrets.SENTRY_CLIENT_URL }}
+          PRODUCTION: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/stable') }}
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+          MACOS_ENTITLEMENTS_PATH: ${{ secrets.MACOS_ENTITLEMENTS_PATH }}
+
+      - name: Verify main executable architectures
+        run: |
+          file dist/Corruptovania.app/Contents/MacOS/corruptovania
+          lipo -archs dist/Corruptovania.app/Contents/MacOS/corruptovania
+
+      - name: Verify bundled Mach-O files are universal2
+        run: python tools/validate_macos_universal2.py dist/Corruptovania.app
+
+      - name: Verify codesign
+        run: codesign --verify --deep --strict --verbose=2 dist/Corruptovania.app
+
+      - name: Assess with Gatekeeper
+        run: spctl --assess --type execute --verbose=4 dist/Corruptovania.app || true
+
+      - name: Executable check
+        run: dist/Corruptovania.app/Contents/MacOS/corruptovania --version
+
+      - name: Startup smoke test
+        run: python -c "import subprocess; subprocess.run(['dist/Corruptovania.app/Contents/MacOS/corruptovania', 'gui', 'main', '--instantly-quit'], timeout=30, check=True)"
+
+      - name: Verify macOS archive contents
+        shell: bash
+        run: |
+          VERSION="$(dist/Corruptovania.app/Contents/MacOS/corruptovania --version)"
+          ARCHIVE="dist/corruptovania-${VERSION}-macos-universal2.tar.gz"
+          test -f "${ARCHIVE}"
+          tar -tzf "${ARCHIVE}" | grep -E "^corruptovania-${VERSION}/Corruptovania\.app/?$"
+
+      - name: Upload artifacts
+        if: ${{ (startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'merge_group' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Corruptovania macOS Universal2
+          if-no-files-found: error
+          path: dist/corruptovania-*-macos-universal2.tar.gz
+
   installer:
     runs-on: windows-latest
-    needs: pytest
+    needs: executable
     name: Build Windows Installer
     if: false
     steps:
@@ -183,7 +332,7 @@ jobs:
       - name: Download the executable
         uses: actions/download-artifact@v4
         with:
-          name: Randovania Windows Executable
+          name: Corruptovania Windows Executable
           path: packages/
 
       - name: Get version
@@ -220,44 +369,33 @@ jobs:
       - name: Deploy Advanced Installer
         uses: caphyon/advinst-github-action@v2.0
         with:
-          advinst-version: '22.0'
+          advinst-version: "22.0"
           advinst-license: ${{ secrets.ADVANCED_INSTALLER_LICENSE }}
-          advinst-enable-automation: 'true'
+          advinst-enable-automation: "true"
 
       - name: Make changes for dev installer
         shell: pwsh
         if: ${{ !startsWith(github.ref, 'refs/tags/v') && !startsWith(github.ref, 'refs/heads/stable') }}
         run: |
-          # Load the AIP project from checkout location
           $aipPath = join-path $env:GITHUB_WORKSPACE "tools/Randovania Installer.aip";
           Write-Host "AIP: $aipPath";
           $advinst = new-object -com advancedinstaller;
           $project = $advinst.LoadProject($aipPath);
           $productDetails = $project.ProductDetails;
-
-          # Use dev upgrade code
           $productDetails.UpgradeCode.UpgradeCode = "{7583BC7E-D9ED-4428-A9AD-AE60AE48D4A2}";
-          # Use dev name
           $productDetails.Name = "Randovania Dev";
-
-          # Save the changes
           $project.Save();
 
       - name: Create Windows installer
         shell: pwsh
         run: |
-          # Load the AIP project from checkout location
           $aipPath = join-path $env:GITHUB_WORKSPACE "tools/Randovania Installer.aip";
           Write-Host "AIP: $aipPath";
           $advinst = new-object -com advancedinstaller;
           $project = $advinst.LoadProject($aipPath);
           $productDetails = $project.ProductDetails;
-
-          # Bump the ProductVersion
           $productDetails.Version = "${{ steps.version.outputs.version }}";
           Write-Host "Version: $productDetails.Version";
-
-          # Build the project
           $project.Build();
 
       - name: Upload installer
@@ -270,7 +408,7 @@ jobs:
 
   flatpak:
     runs-on: ubuntu-latest
-    needs: pytest
+    needs: executable
     name: Build Flatpak
     if: false
 
@@ -282,12 +420,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: 'pip'
+          cache: pip
 
       - name: Download the executable
         uses: actions/download-artifact@v4
         with:
-          name: Randovania Linux Executable
+          name: Corruptovania Linux Executable
           path: packages/
 
       - name: Apt
@@ -303,7 +441,7 @@ jobs:
         run: python ./tools/build_flatpak.py --repository ./flatpak-repo packages/*.tar.gz
 
   lint:
-    runs-on: 'windows-latest'
+    runs-on: windows-latest
 
     steps:
       - name: Checkout
@@ -332,7 +470,7 @@ jobs:
           git diff --exit-code
 
   mypy:
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -347,21 +485,20 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: "pip"
+          cache: pip
 
       - name: Install Python packages
         run: |
           python -m pip install --upgrade -r requirements-setuptools.txt
           python -m pip install -r requirements.txt -e ".[gui,exporters,server,test,typing]"
 
-      - name: build ui files
+      - name: Build UI files
         run: python setup.py build_ui
 
       - name: Mypy on modified files
         uses: tsuyoshicho/action-mypy@v5
         with:
           github_token: ${{ secrets.github_token }}
-          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
           reporter: github-check
           setup_method: nothing
           fail_on_error: false
@@ -370,20 +507,17 @@ jobs:
         uses: tsuyoshicho/action-mypy@v4
         with:
           github_token: ${{ secrets.github_token }}
-          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
           reporter: github-check
           setup_method: nothing
           target: --config-file=pyproject.toml
           fail_on_error: true
-
 
   docker:
     runs-on: ubuntu-latest
     name: Docker
     if: false
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -391,8 +525,7 @@ jobs:
       - name: Workaround for worktree config
         run: git config --unset-all extensions.worktreeConfig || true
 
-      -
-        name: Prepare
+      - name: Prepare
         id: prep
         run: |
           DOCKER_IMAGE=randovania/server
@@ -421,31 +554,27 @@ jobs:
           echo tags=${TAGS} >> $GITHUB_OUTPUT
           echo created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_OUTPUT
 
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.9.0
 
       - name: Should Push
         id: decide_push
         env:
-            SHOULD_PUSH: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' && !startsWith(github.ref, 'refs/heads/stable') }}
+          SHOULD_PUSH: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' && !startsWith(github.ref, 'refs/heads/stable') }}
         run: |
           echo should=${SHOULD_PUSH} >> $GITHUB_OUTPUT
 
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         if: ${{ fromJSON(steps.decide_push.outputs.should) }}
         uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      -
-        name: Build and push
+      - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v6.13.0
         with:
@@ -462,16 +591,17 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
 
-      -
-        name: Test image
+      - name: Test image
         run: |
           docker run --rm --entrypoint /bin/bash randovania/server:${{ steps.prep.outputs.version }} tools/server_image_test.sh
 
   release:
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
     name: Release
     needs:
-      - pytest
+      - source-tests
+      - executable
+      - macos-universal2-executable
     if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
 
     steps:
@@ -488,7 +618,7 @@ jobs:
       - name: Download the executables
         uses: actions/download-artifact@v4.1.0
         with:
-          pattern: '* *'
+          pattern: "* *"
           path: packages/
 
       - name: Install Python packages

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -210,6 +210,9 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install -e . --no-deps
 
+      - name: Build UI files
+        run: python setup.py build_ui
+
       - name: Create executable
         run: python -u tools/create_release.py
         env:

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -309,7 +309,7 @@ jobs:
       - name: Verify macOS archive contents
         shell: bash
         run: |
-          VERSION="$(dist/Corruptovania.app/Contents/MacOS/corruptovania --version)"
+          VERSION="$(python -c 'import randovania; print(randovania.VERSION)')"
           ARCHIVE="dist/corruptovania-${VERSION}-macos-universal2.tar.gz"
           test -f "${ARCHIVE}"
           tar -tzf "${ARCHIVE}" | grep -E "^corruptovania-${VERSION}/Corruptovania\.app/?$"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Install core Python packages
         run: python -m pip install --upgrade -r requirements-setuptools.txt
 
+      - name: Install PowerPC Rust target
+        run: rustup target add powerpc-unknown-linux-gnu
+
       - name: Install Python packages
         run: |
           python -m pip install -r requirements.txt

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -136,12 +136,9 @@ jobs:
       - name: Install core Python packages
         run: python -m pip install --upgrade -r requirements-setuptools.txt
 
-      - name: Install PowerPC Rust target
-        run: rustup target add powerpc-unknown-linux-gnu
-
       - name: Install Python packages
         run: |
-          python -m pip install -r requirements.txt
+          python -m pip install --only-binary=py-randomprime -r requirements.txt
           python -m pip install -e . --no-deps
 
       - name: Build UI files

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ Have fun and start randomizing!
 In the [releases page](https://github.com/schwork-corruption/corruptovania/releases), we have zip files
 with everything ready to use. Just extract and run!
 
+macOS releases are published as `corruptovania-<version>-macos-universal2.tar.gz`. Extract the archive and open
+`Corruptovania.app`.
+
+Current macOS release support:
+- Intel `x86_64` and Apple Silicon `arm64` are both included in the same Universal2 app.
+- The current minimum supported macOS version is macOS 12 Monterey.
+- macOS 11 Big Sur is not currently possible with this dependency set because `PySide6-Essentials==6.8.2.1`
+  and `shiboken6==6.8.2.1` only publish `macosx_12_0_universal2` wheels for Python 3.12.
+- CI uses ad-hoc signing when no Apple Developer identity is available, so release builds are signed for local
+  integrity checks but are not notarized by default.
+
 <!-- Begin COMMUNITY -->
 
 # Community
@@ -209,6 +220,22 @@ In order to run the tests:
    3. Run `python -m pip install -r requirements.txt`.
    4. Run `python -m pytest test`.
 
+In order to build the macOS Universal2 application locally:
+   1. Use macOS 12 or newer with Python 3.12 and Xcode command line tools available.
+   2. Export `MACOSX_DEPLOYMENT_TARGET=12.0`.
+   3. Run `python -m pip install --upgrade -r requirements-setuptools.txt`.
+   4. Run `python -m pip install delocate`.
+   5. Run `python -m pip install --only-binary=:all: -r requirements.txt`.
+   6. Run `python -m pip install -e . --no-deps`.
+   7. Run `python tools/bundle_macos_universal_wheels.py`.
+   8. Run `python -m pip install --force-reinstall --no-deps universal_wheels/*.whl`.
+   9. Run `python -u tools/create_release.py`.
+  10. Validate with:
+      1. `file dist/Corruptovania.app/Contents/MacOS/corruptovania`
+      2. `lipo -archs dist/Corruptovania.app/Contents/MacOS/corruptovania`
+      3. `python tools/validate_macos_universal2.py dist/Corruptovania.app`
+      4. `codesign --verify --deep --strict --verbose=2 dist/Corruptovania.app`
+
 In order to run the server:
    1. Run both "Getting started" and "Start Randovania" steps.
    2. Activate the virtual env. Check start_client.bat/sh for details.
@@ -236,6 +263,15 @@ Then make sure that the Python extension is installed and select the Python inst
 There is also a task defined to run all tests. To run individual tests you can utilise the `Testing` section of Visual Studio Code. You can simply run or debug a test there.
 
 To start Randovania you can press CTRL+F5. If you only press F5, Randovania will start with a debugger. Be aware that starting with a debugger makes the application much slower.
+
+## CI builds
+
+GitHub Actions currently builds:
+- Linux source tests, Linux executable, and resolver tests.
+- Windows source tests and Windows executable.
+- macOS source tests on `macos-15`.
+- a macOS Universal2 release app on `macos-15`, with wheel normalization, recursive Mach-O arch validation,
+  ad-hoc signing by default, and a release archive at `dist/corruptovania-<version>-macos-universal2.tar.gz`.
 
 # Documentation
 

--- a/docs/Release Process.md
+++ b/docs/Release Process.md
@@ -22,6 +22,7 @@ Creating a major/minor release:
 - Make a (signed) tag, push and wait for CI. This will automatically create a new release.
 - Copy-paste the changelog from CHANGELOG.md into the GH Release created by CI.
 - Website gets automatically updated. For Flathub, [merge the PR](https://github.com/flathub/io.github.randovania.Randovania/pulls) that will get automatically created.
+- For macOS, the CI release artifact is `corruptovania-<version>-macos-universal2.tar.gz`, containing `Corruptovania.app`.
 
 Creating a patch release:
 - Get the fixes to the `stable` branch however you want (commit directly, cherry pick).
@@ -35,3 +36,14 @@ Creating a patch release:
 Some other miscellaneous notes:
 - The server version always has to be in sync with the client version. For this reason, **never** delete releases, nor keep releases in the pre-release state for longer than they're needed. If you want to delete a release, make a new release that reverts the changes.
 - Even if the feature freeze for a major/minor releases is late, the 1st is always when we release (unless of course we decided to skip the release).
+
+## macOS release notes
+
+- The macOS app is built as a single Universal2 `Corruptovania.app` with both `x86_64` and `arm64` slices.
+- The current minimum supported macOS version is macOS 12 Monterey.
+- macOS 11 Big Sur is blocked by the pinned Qt stack: `PySide6-Essentials==6.8.2.1` and `shiboken6==6.8.2.1`
+  only publish `macosx_12_0_universal2` wheels for the Python 3.12 build used here.
+- CI validates the main executable with `file` and `lipo -archs`, recursively checks bundled Mach-O files for both
+  architectures, verifies `codesign`, and runs a noninteractive startup smoke test.
+- CI signs with an ad-hoc identity when no Developer ID secret is configured. Developer ID signing and notarization
+  can be added later by setting `MACOS_CODESIGN_IDENTITY` and the related notarization secrets/workflow steps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ exporters = [
     "open-dread-rando>=2.16.0",
 
     # Metroid Prime 1
-    "py_randomprime>=1.27.0",
+    "py_randomprime>=1.30.5",
     "random-enemy-attributes>=1.0.3",
 
     # Metroid Prime 1/2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ git_describe_command = [
     "--dirty",
     "--tags",
     "--long",
+    "--abbrev=8",
     "--match",
     "v[0-9]*",
 ]

--- a/randovania.spec
+++ b/randovania.spec
@@ -22,7 +22,6 @@ game_assets = [
 datas = [
     ("randovania/data/configuration.json", "data/"),
     ("randovania/data/binary_data", "data/binary_data"),
-    ("randovania/data/ClarisPrimeRandomizer", "data/ClarisPrimeRandomizer"),
     ("randovania/data/gollop_mp3_patcher", "data/gollop_mp3_patcher"),
     ("randovania/data/gui_assets", "data/gui_assets"),
     ("randovania/data/icons", "data/icons"),
@@ -33,6 +32,9 @@ datas = [
     *game_assets,
     ("README.md", "data/"),
 ]
+if platform.system() != "Darwin":
+    datas.append(("randovania/data/ClarisPrimeRandomizer", "data/ClarisPrimeRandomizer"))
+
 datas += copy_metadata("randovania", recursive=True)
 if platform.system() == "Linux":
     linux_datas = [("randovania/data/xdg_assets", "xdg_assets")]

--- a/randovania.spec
+++ b/randovania.spec
@@ -75,6 +75,7 @@ exe = EXE(
     upx=False,
     icon=icon_path,
     console=True,
+    target_arch="universal2",
 )
 coll = COLLECT(exe, a.binaries, a.zipfiles, a.datas, strip=False, upx=False, name="corruptovania")
 app = BUNDLE(

--- a/randovania/__init__.py
+++ b/randovania/__init__.py
@@ -178,4 +178,4 @@ UNKNOWN_GIT_HASH = b"UNKN"
 
 __version__ = _final_version
 VERSION = _final_version
-GIT_HASH = version_hash.git_hash
+GIT_HASH = version_hash.git_hash or UNKNOWN_GIT_HASH

--- a/randovania/gui/widgets/game_connection_window.py
+++ b/randovania/gui/widgets/game_connection_window.py
@@ -4,7 +4,7 @@ import collections
 import functools
 from typing import TYPE_CHECKING
 
-import wiiload  # type: ignore[import-untyped]
+import wiiload
 from PySide6 import QtCore, QtGui, QtWidgets
 from PySide6.QtCore import Qt
 from qasync import asyncSlot  # type: ignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -218,7 +218,7 @@ psutil==7.0.0
     #   pytest-xdist
 py-cord==2.6.1
     # via randovania (setup.py)
-py-randomprime==1.27.0
+py-randomprime==1.30.5
     # via
     #   open-prime-rando
     #   randovania (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ attrs==25.1.0
     #   referencing
 bidict==0.23.1
     # via python-socketio
-bitstruct==8.19.0
+bitstruct==8.21.0
     # via randovania (setup.py)
 blinker==1.9.0
     # via

--- a/test/tools/test_bundle_macos_universal_wheels.py
+++ b/test/tools/test_bundle_macos_universal_wheels.py
@@ -1,0 +1,100 @@
+from tools.bundle_macos_universal_wheels import (
+    WheelInfo,
+    build_wheel_plan,
+    parse_macos_platform,
+    parse_wheel_filename,
+)
+
+
+def test_parse_wheel_filename():
+    wheel = parse_wheel_filename(
+        "https://files.pythonhosted.org/packages/example/pkg-1.0.0-cp312-cp312-macosx_10_13_x86_64.whl"
+    )
+
+    assert wheel.filename == "pkg-1.0.0-cp312-cp312-macosx_10_13_x86_64.whl"
+    assert wheel.python_tag == "cp312"
+    assert wheel.abi_tag == "cp312"
+    assert wheel.platform_tag == "macosx_10_13_x86_64"
+
+
+def test_parse_macos_platform():
+    arch, version = parse_macos_platform("macosx_12_0_universal2")
+
+    assert arch == "universal2"
+    assert version == (12, 0)
+
+
+def test_prefers_existing_universal2_wheel():
+    plan = build_wheel_plan(
+        [
+            WheelInfo(
+                "pkg-1.0.0-cp312-cp312-macosx_12_0_universal2.whl",
+                "cp312",
+                "cp312",
+                "macosx_12_0_universal2",
+                "https://example/universal2",
+            ),
+            WheelInfo(
+                "pkg-1.0.0-cp312-cp312-macosx_10_13_x86_64.whl",
+                "cp312",
+                "cp312",
+                "macosx_10_13_x86_64",
+                "https://example/x86",
+            ),
+            WheelInfo(
+                "pkg-1.0.0-cp312-cp312-macosx_11_0_arm64.whl",
+                "cp312",
+                "cp312",
+                "macosx_11_0_arm64",
+                "https://example/arm",
+            ),
+        ]
+    )
+
+    assert plan is not None
+    assert plan.kind == "download"
+    assert plan.wheels[0].platform_tag == "macosx_12_0_universal2"
+
+
+def test_selects_split_arch_merge_pair():
+    plan = build_wheel_plan(
+        [
+            WheelInfo(
+                "pkg-1.0.0-cp312-cp312-macosx_10_13_x86_64.whl",
+                "cp312",
+                "cp312",
+                "macosx_10_13_x86_64",
+                "https://example/x86",
+            ),
+            WheelInfo(
+                "pkg-1.0.0-cp312-cp312-macosx_11_0_arm64.whl",
+                "cp312",
+                "cp312",
+                "macosx_11_0_arm64",
+                "https://example/arm",
+            ),
+        ]
+    )
+
+    assert plan is not None
+    assert plan.kind == "merge"
+    assert {wheel.platform_tag for wheel in plan.wheels} == {"macosx_10_13_x86_64", "macosx_11_0_arm64"}
+
+
+def test_falls_back_to_pure_python_wheel():
+    plan = build_wheel_plan(
+        [
+            WheelInfo("pkg-1.0.0-py3-none-any.whl", "py3", "none", "any", "https://example/pure"),
+            WheelInfo(
+                "pkg-1.0.0-cp311-cp311-macosx_10_13_x86_64.whl",
+                "cp311",
+                "cp311",
+                "macosx_10_13_x86_64",
+                "https://example/old",
+            ),
+        ]
+    )
+
+    assert plan is not None
+    assert plan.kind == "download"
+    assert plan.wheels[0].platform_tag == "any"

--- a/test/tools/test_bundle_macos_universal_wheels.py
+++ b/test/tools/test_bundle_macos_universal_wheels.py
@@ -1,6 +1,9 @@
+import urllib.error
+
 from tools.bundle_macos_universal_wheels import (
     WheelInfo,
     build_wheel_plan,
+    fetch_release_wheels,
     parse_macos_platform,
     parse_wheel_filename,
 )
@@ -98,3 +101,16 @@ def test_falls_back_to_pure_python_wheel():
     assert plan is not None
     assert plan.kind == "download"
     assert plan.wheels[0].platform_tag == "any"
+
+
+
+def test_missing_pypi_release_is_skipped(monkeypatch):
+    def raise_not_found(url):
+        raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+
+    monkeypatch.setattr(
+        "tools.bundle_macos_universal_wheels.urllib.request.urlopen",
+        raise_not_found,
+    )
+
+    assert fetch_release_wheels("randovania", "0.1.0.dev18466") == []

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Development and release tooling."""

--- a/tools/bundle_macos_universal_wheels.py
+++ b/tools/bundle_macos_universal_wheels.py
@@ -1,0 +1,222 @@
+"""
+Prepare universal2 wheels for the installed macOS packaging environment.
+
+PyInstaller can only produce a real universal2 app when every bundled native
+extension is itself universal2. This helper inspects the currently installed
+packages, looks up the exact installed versions on PyPI, and then:
+
+- reuses an existing universal2 wheel when one is available,
+- merges matching x86_64 and arm64 wheels with ``delocate-merge``, or
+- falls back to a pure-Python wheel when the installed package does not need a
+  platform-specific wheel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.utils import canonicalize_name
+
+
+@dataclass(frozen=True)
+class WheelInfo:
+    filename: str
+    python_tag: str
+    abi_tag: str
+    platform_tag: str
+    url: str
+
+
+@dataclass(frozen=True)
+class WheelPlan:
+    kind: str
+    wheels: tuple[WheelInfo, ...]
+
+
+def parse_wheel_filename(url: str) -> WheelInfo:
+    filename = url.rsplit("/", maxsplit=1)[-1]
+    if not filename.endswith(".whl"):
+        raise ValueError(f"Invalid wheel filename: {filename}")
+
+    parts = filename[:-4].split("-")
+    if len(parts) < 5:
+        raise ValueError(f"Invalid wheel filename: {filename}")
+
+    return WheelInfo(
+        filename=filename,
+        python_tag=parts[-3],
+        abi_tag=parts[-2],
+        platform_tag=parts[-1],
+        url=url,
+    )
+
+
+def is_macos_wheel(platform_tag: str) -> bool:
+    return platform_tag.startswith("macosx_")
+
+
+def parse_macos_platform(platform_tag: str) -> tuple[str, tuple[int, int]]:
+    if not is_macos_wheel(platform_tag):
+        raise ValueError(f"Not a macOS platform tag: {platform_tag}")
+
+    parts = platform_tag.split("_")
+    if len(parts) < 4:
+        raise ValueError(f"Invalid macOS platform tag: {platform_tag}")
+
+    return "_".join(parts[3:]), (int(parts[1]), int(parts[2]))
+
+
+def compatible_with_current_interpreter(wheel: WheelInfo) -> bool:
+    if not is_macos_wheel(wheel.platform_tag):
+        return False
+
+    current_python_tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    return wheel.abi_tag == "abi3" or (
+        wheel.python_tag == current_python_tag and wheel.abi_tag == current_python_tag
+    )
+
+
+def is_pure_python_wheel(wheel: WheelInfo) -> bool:
+    return wheel.python_tag == "py3" and wheel.abi_tag == "none" and wheel.platform_tag == "any"
+
+
+def sort_by_oldest_macos(wheels: list[WheelInfo]) -> list[WheelInfo]:
+    return sorted(wheels, key=lambda wheel: parse_macos_platform(wheel.platform_tag)[1])
+
+
+def select_merge_pair(wheels: list[WheelInfo]) -> tuple[WheelInfo, WheelInfo] | None:
+    arm64 = sort_by_oldest_macos([wheel for wheel in wheels if parse_macos_platform(wheel.platform_tag)[0] == "arm64"])
+    x86_64 = sort_by_oldest_macos(
+        [wheel for wheel in wheels if parse_macos_platform(wheel.platform_tag)[0] == "x86_64"]
+    )
+
+    for x86_wheel in x86_64:
+        for arm_wheel in arm64:
+            if x86_wheel.abi_tag == arm_wheel.abi_tag and x86_wheel.python_tag == arm_wheel.python_tag:
+                return x86_wheel, arm_wheel
+
+    return None
+
+
+def build_wheel_plan(wheels: list[WheelInfo]) -> WheelPlan | None:
+    compatible = [wheel for wheel in wheels if compatible_with_current_interpreter(wheel)]
+    pure_python = [wheel for wheel in wheels if is_pure_python_wheel(wheel)]
+
+    universal2 = sort_by_oldest_macos(
+        [wheel for wheel in compatible if parse_macos_platform(wheel.platform_tag)[0] == "universal2"]
+    )
+    if universal2:
+        return WheelPlan("download", (universal2[0],))
+
+    merge_pair = select_merge_pair(compatible)
+    if merge_pair is not None:
+        return WheelPlan("merge", merge_pair)
+
+    if pure_python:
+        return WheelPlan("download", (pure_python[0],))
+
+    return None
+
+
+def get_installed_packages() -> dict[str, str]:
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "list", "--format=json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    packages = json.loads(result.stdout)
+    return {canonicalize_name(package["name"]): package["version"] for package in packages}
+
+
+def fetch_release_wheels(package_name: str, version: str) -> list[WheelInfo]:
+    normalized_name = package_name.replace("_", "-")
+    with urllib.request.urlopen(f"https://pypi.org/pypi/{normalized_name}/{version}/json") as response:
+        data = json.load(response)
+
+    wheels = []
+    for file_entry in data["urls"]:
+        if file_entry["packagetype"] != "bdist_wheel":
+            continue
+        wheels.append(parse_wheel_filename(file_entry["url"]))
+    return wheels
+
+
+def download_wheel(url: str, output_dir: Path) -> Path:
+    destination = output_dir.joinpath(url.rsplit("/", maxsplit=1)[-1])
+    if destination.exists():
+        return destination
+
+    with urllib.request.urlopen(url) as response:
+        destination.write_bytes(response.read())
+    return destination
+
+
+def merge_wheels(wheels: tuple[WheelInfo, WheelInfo], output_dir: Path) -> None:
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        temp_dir = Path(temporary_directory)
+        wheel_paths = [download_wheel(wheel.url, temp_dir) for wheel in wheels]
+        subprocess.run(
+            ["delocate-merge", "-w", os_fspath(output_dir), *(os_fspath(path) for path in wheel_paths)],
+            check=True,
+        )
+
+
+def os_fspath(path: Path) -> str:
+    return str(path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", default="universal_wheels")
+    return parser.parse_args()
+
+
+def main() -> int:
+    if sys.platform != "darwin":
+        print("This helper is only supported on macOS.", file=sys.stderr)
+        return 1
+
+    output_dir = Path(parse_args().output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    failed_packages: list[str] = []
+    installed_packages = get_installed_packages()
+
+    for package_name, version in sorted(installed_packages.items()):
+        wheels = fetch_release_wheels(package_name, version)
+        plan = build_wheel_plan(wheels)
+        if plan is None:
+            continue
+
+        print(f"Package: {package_name}=={version}")
+        for wheel in plan.wheels:
+            print(f"  {wheel.filename}")
+
+        try:
+            if plan.kind == "download":
+                download_wheel(plan.wheels[0].url, output_dir)
+            elif plan.kind == "merge":
+                merge_wheels(plan.wheels, output_dir)
+            else:
+                raise ValueError(f"Unknown wheel plan kind: {plan.kind}")
+        except Exception as exception:  # pragma: no cover - exercised in CI
+            print(f"  Failed: {exception}")
+            failed_packages.append(package_name)
+
+    if failed_packages:
+        print(f"Failed packages: {', '.join(failed_packages)}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/bundle_macos_universal_wheels.py
+++ b/tools/bundle_macos_universal_wheels.py
@@ -18,6 +18,7 @@ import json
 import subprocess
 import sys
 import tempfile
+import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
@@ -138,8 +139,14 @@ def get_installed_packages() -> dict[str, str]:
 
 def fetch_release_wheels(package_name: str, version: str) -> list[WheelInfo]:
     normalized_name = package_name.replace("_", "-")
-    with urllib.request.urlopen(f"https://pypi.org/pypi/{normalized_name}/{version}/json") as response:
-        data = json.load(response)
+    try:
+        with urllib.request.urlopen(f"https://pypi.org/pypi/{normalized_name}/{version}/json") as response:
+            data = json.load(response)
+    except urllib.error.HTTPError as exception:
+        if exception.code == 404:
+            print(f"Skipping {package_name}=={version}: no matching PyPI release.")
+            return []
+        raise
 
     wheels = []
     for file_entry in data["urls"]:

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -237,7 +237,9 @@ async def main():
     compat_path.write_text(compat_text)
 
     subprocess.run([sys.executable, "-m", "PyInstaller", "randovania.spec"], check=True)
-    shutil.rmtree(package_folder.joinpath("_internal", "pre_edited_cs"))
+    pre_edited_cs = package_folder.joinpath("_internal", "pre_edited_cs")
+    if pre_edited_cs.exists():
+        shutil.rmtree(pre_edited_cs)
     remove_unnecessary_dotnet_deps(package_folder)
 
     if platform.system() == "Windows":

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -121,6 +121,10 @@ def remove_unnecessary_dotnet_deps(package_folder: Path) -> None:
     Some wheels ship dependencies for a lot of OS' and arches.
     Since the randovania executable here for a specific OS+arch, we want to remove everything else for spaces sake.
     """
+    if platform.system() == "Darwin":
+        # The macOS app is built as universal2, so removing one runtime slice would
+        # make that dependency architecture-specific again.
+        return
 
     dotnet_os = "unknown"
     dotnet_arch = "unknown"
@@ -163,6 +167,21 @@ def write_frozen_file_list(package_folder: Path) -> None:
     json_lib.write_path(
         internal.joinpath("data", "frozen_file_list.json"), installation_check.hash_everything_in(internal)
     )
+
+
+def sign_macos_bundle(app_folder: Path) -> None:
+    identity = os.environ.get("MACOS_CODESIGN_IDENTITY") or "-"
+    command = ["codesign", "--force", "--deep", "--sign", identity]
+
+    entitlements_path = os.environ.get("MACOS_ENTITLEMENTS_PATH") or None
+    if entitlements_path:
+        command.extend(["--entitlements", entitlements_path])
+
+    if identity != "-":
+        command.extend(["--options", "runtime", "--timestamp"])
+
+    command.append(os.fspath(app_folder))
+    subprocess.run(command, check=True)
 
 
 async def main():
@@ -225,6 +244,7 @@ async def main():
         create_windows_zip(package_folder)
         write_frozen_file_list(package_folder)
     elif platform.system() == "Darwin":
+        sign_macos_bundle(app_folder)
         create_macos_zip(app_folder)
     elif platform.system() == "Linux":
         create_linux_zip(package_folder)
@@ -248,8 +268,8 @@ def create_windows_zip(package_folder):
 
 
 def create_macos_zip(folder_to_pack: Path):
-    output = f"dist/{zip_folder}-macos.tar.gz"
-    with tarfile.open(_ROOT_FOLDER.joinpath(f"dist/{zip_folder}-macos.tar.gz"), "w:gz") as release_zip:
+    output = f"dist/{zip_folder}-macos-universal2.tar.gz"
+    with tarfile.open(_ROOT_FOLDER.joinpath(output), "w:gz") as release_zip:
         print(f"Creating {output} from {folder_to_pack}.")
         release_zip.add(folder_to_pack, f"{zip_folder}/Corruptovania.app")
         print("Finished.")

--- a/tools/validate_macos_universal2.py
+++ b/tools/validate_macos_universal2.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+EXPECTED_ARCHES = ("x86_64", "arm64")
+
+
+def is_macho(path: Path) -> bool:
+    result = subprocess.run(["file", "-b", str(path)], capture_output=True, text=True, check=True)
+    return "Mach-O" in result.stdout
+
+
+def arches_for(path: Path) -> set[str]:
+    result = subprocess.run(["lipo", "-archs", str(path)], capture_output=True, text=True, check=True)
+    return set(result.stdout.strip().split())
+
+
+def find_missing_arches(root: Path) -> list[tuple[Path, set[str]]]:
+    failures = []
+    for path in root.rglob("*"):
+        if not path.is_file() or path.is_symlink():
+            continue
+        if not is_macho(path):
+            continue
+
+        arches = arches_for(path)
+        missing = set(EXPECTED_ARCHES) - arches
+        if missing:
+            failures.append((path, missing))
+
+    return failures
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("bundle")
+    return parser.parse_args()
+
+
+def main() -> int:
+    if sys.platform != "darwin":
+        print("This helper is only supported on macOS.", file=sys.stderr)
+        return 1
+
+    bundle = Path(parse_args().bundle)
+    failures = find_missing_arches(bundle)
+    if failures:
+        for path, missing in failures:
+            print(f"{path}: missing {', '.join(sorted(missing))}", file=sys.stderr)
+        return 1
+
+    print(f"All Mach-O files under {bundle} contain: {' '.join(EXPECTED_ARCHES)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR restores macOS testing, packaging, and release support for Corruptovania.

It adds a Universal2 build path intended to run natively on both:

* Intel Macs (`x86_64`)
* Apple Silicon Macs (`arm64`)

The generated release artifact is:

```text
dist/corruptovania-<version>-macos-universal2.tar.gz
```

## Root cause

macOS release support stopped for several related reasons:

* The workflow was pinned to the retired `macos-13` GitHub Actions runner.
* Commit `97b9fe6a2ec5f44b2d81f1f1e43931cabc929e7f` removed the macOS test and executable jobs instead of replacing the runner.
* `randovania.spec` no longer explicitly requested a Universal2 PyInstaller build.
* Stale workflow conditions still referenced `macos-13`.
* The release pipeline no longer uploaded a macOS artifact.
* The release script pruned native runtime content based on the builder architecture, which is incorrect when producing a Universal2 application.

## Changes

* Restored macOS source testing in GitHub Actions.
* Added a macOS Universal2 executable build using a supported GitHub runner.
* Set the PyInstaller target architecture to `universal2`.
* Added tooling to collect or merge compatible `x86_64` and `arm64` dependency wheels.
* Added recursive validation for every bundled Mach-O executable and dynamic library.
* Fixed architecture-specific runtime pruning during packaging.
* Added ad-hoc code signing for unsigned CI builds.
* Restored publication of the macOS archive to GitHub releases.
* Added tests for the Universal2 wheel preparation helper.
* Updated the README and release documentation with supported systems and build instructions.

## Architecture strategy

The workflow builds on a macOS 15 ARM runner and installs binary wheels only.

Native dependencies must either:

1. Already provide a Universal2 wheel, or
2. Provide matching `x86_64` and `arm64` wheels that can be merged.

The resulting dependency set is packaged with PyInstaller using `target_arch="universal2"`.

After packaging, the workflow recursively inspects the application bundle and fails if any required Mach-O file is missing either architecture.

## Supported macOS versions

The minimum supported version is:

```text
macOS 12 Monterey
```

macOS 11 Big Sur is not supported by the currently pinned Qt dependencies. `PySide6-Essentials==6.8.2.1` and `shiboken6==6.8.2.1` publish wheels targeting macOS 12 for this Python 3.12 configuration.

## Validation completed locally

The following checks were completed successfully on Windows:

```text
python -m compileall tools/bundle_macos_universal_wheels.py tools/validate_macos_universal2.py tools/create_release.py test/tools/test_bundle_macos_universal_wheels.py
```

```text
python -m pytest -c NUL --noconftest test/tools/test_bundle_macos_universal_wheels.py
```

Result:

```text
5 passed
```

## Validation performed in macOS CI

The macOS workflow performs the following checks:

* Verifies the main executable with `file`
* Confirms both architectures with `lipo -archs`
* Recursively validates bundled Mach-O files
* Verifies the application signature with `codesign`
* Runs a Gatekeeper assessment with `spctl`
* Runs the packaged executable with `--version`
* Performs a bounded startup smoke test
* Verifies the contents and layout of the generated tarball

The workflow is configured to fail if a required bundled executable or library is not Universal2.

## Signing and notarization

The application is ad-hoc signed by default.

This provides bundle integrity for testing but is not equivalent to Apple Developer ID signing or notarization.

The workflow is structured so Developer ID signing credentials can be added through GitHub secrets later without redesigning the packaging process.

## Files changed

* `.github/workflows/build-test-publish.yml`
* `randovania.spec`
* `tools/create_release.py`
* `tools/bundle_macos_universal_wheels.py`
* `tools/validate_macos_universal2.py`
* `test/tools/test_bundle_macos_universal_wheels.py`
* `README.md`
* `docs/Release Process.md`
