### PR TITLE
Gel Refinery Site Adjustments

### DIFF
--- a/CHANGELOG_MP3.md
+++ b/CHANGELOG_MP3.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### Bryyo
 - Added: Gel Refinery Site: A way of scaling to the item without bombs using Space Jump and Screw Attack from the Refinery Access Door Ledge. 
-- Fixed: Gel Refinery Site: The Bomb Space Jump up to the item has had its trick level raised from Expert to Hypermode. 
 - Changed: Gel Refinery Site: Getting from the item to Gel Purification Site with just Space Jump Boots has been lowered from Intermediate to Beginner movement.
 
 ## [1.8.2] - 2026-03-07

--- a/CHANGELOG_MP3.md
+++ b/CHANGELOG_MP3.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Major** - Added: Prime 3 game exporting is now supported on macOS using bundled .NET 8 runtimes and native helper tools, with no system-wide .NET installation required.
 - Changed: Prime 3 helper resolution, extraction, command construction, temporary-file cleanup, and failure diagnostics have been refactored for cross-platform use.
 
+#### Logic Database
+
+##### Bryyo
+- Added: Gel Refinery Site: A way of scaling to the item without bombs using Space Jump and Screw Attack from the Refinery Access Door Ledge. 
+- Fixed: Gel Refinery Site: The Bomb Space Jump up to the item has had its trick level raised from Expert to Hypermode. 
+- Changed: Gel Refinery Site: Getting from the item to Gel Purification Site with just Space Jump Boots has been lowered from Intermediate to Beginner movement.
+
 ## [1.8.2] - 2026-03-07
 
 #### Logic Database

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -1833,7 +1833,7 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Use Screw Attack (No Space Jump)"
+                                                                "data": "Use Screw Attack (Space Jump)"
                                                             },
                                                             {
                                                                 "type": "resource",
@@ -1852,7 +1852,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "BSJ",
-                                                        "amount": 4,
+                                                        "amount": 5,
                                                         "negate": false
                                                     }
                                                 }
@@ -2069,6 +2069,36 @@
                                             "type": "tricks",
                                             "name": "SlopeJump",
                                             "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Pickup (Missile Expansion)": {
+                            "type": "and",
+                            "data": {
+                                "comment": "Jump and Space Jump Low to the ground and activate Screw after slope jumping over",
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Use Screw Attack (Space Jump)"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Knowledge",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "SlopeJump",
+                                            "amount": 2,
                                             "negate": false
                                         }
                                     }

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -1629,7 +1629,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "Movement",
-                                                        "amount": 2,
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -1852,7 +1852,7 @@
                                                     "data": {
                                                         "type": "tricks",
                                                         "name": "BSJ",
-                                                        "amount": 5,
+                                                        "amount": 4,
                                                         "negate": false
                                                     }
                                                 }

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -220,7 +220,7 @@ Extra - asset_id: 691790544662692104
   > Door to Gel Purification Site
       Any of the following:
           After Gel Refinery Site Pipe or Use Screw Attack (Space Jump)
-          Space Jump Boots and Movement (Intermediate)
+          Space Jump Boots and Movement (Beginner)
   > Room Center
       Trivial
 

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -246,7 +246,7 @@ Extra - asset_id: 691790544662692104
           Morph Ball Bomb and Space Jump Boots and Morph Ball
           Any of the following:
               # https://youtu.be/ihLjH0TGkIg
-              Bomb/Spring Space Jump (Hypermode)
+              Bomb/Spring Space Jump (Expert)
               # https://youtu.be/_sSWzSqM_0g
               Bomb/Spring Space Jump (Advanced) and Use Screw Attack (Space Jump)
   > Ledge by Refinery Access Door

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -246,9 +246,9 @@ Extra - asset_id: 691790544662692104
           Morph Ball Bomb and Space Jump Boots and Morph Ball
           Any of the following:
               # https://youtu.be/ihLjH0TGkIg
-              Bomb/Spring Space Jump (Expert)
+              Bomb/Spring Space Jump (Hypermode)
               # https://youtu.be/_sSWzSqM_0g
-              Bomb/Spring Space Jump (Advanced) and Use Screw Attack (No Space Jump)
+              Bomb/Spring Space Jump (Advanced) and Use Screw Attack (Space Jump)
   > Ledge by Refinery Access Door
       Any of the following:
           Plasma Beam and Can Use Bombs
@@ -273,6 +273,9 @@ Extra - asset_id: 691790544662692104
   > Door to Gel Purification Site
       # https://youtu.be/66_fmkS3vOk
       Movement (Intermediate) and Slope Jump (Beginner) and Use Screw Attack (Space Jump)
+  > Pickup (Missile Expansion)
+      # Jump and Space Jump Low to the ground and activate Screw after slope jumping over
+      Knowledge (Advanced) and Slope Jump (Intermediate) and Use Screw Attack (Space Jump)
   > Room Center
       Trivial
 


### PR DESCRIPTION
Redid on a different branch and added changelog fixes.

- Added: Gel Refinery Site: A way of scaling to the item without bombs using Space Jump and Screw Attack from the Refinery Access Door Ledge. 
- Fixed: Gel Refinery Site: The Bomb Space Jump up to the item has had its trick level raised from Expert to Hypermode. 
- Changed: Gel Refinery Site: Getting from the item to Gel Purification Site with just Space Jump Boots has been lowered from Intermediate to Beginner movement.