### PR TITLE
Omega Ridley Energy Reqs. and Lasso Fix

### DIFF
--- a/CHANGELOG_MP3.md
+++ b/CHANGELOG_MP3.md
@@ -15,8 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Logic Database
 
 ##### Bryyo
+
 - Added: Gel Refinery Site: A way of scaling to the item without bombs using Space Jump and Screw Attack from the Refinery Access Door Ledge. 
 - Changed: Gel Refinery Site: Getting from the item to Gel Purification Site with just Space Jump Boots has been lowered from Intermediate to Beginner movement.
+
+##### Pirate Homeworld
+
+- Fixed: Omega Ridley now correctly requires Grapple Lasso to beat and now has minimum energy and combat requirements.
 
 ## [1.8.2] - 2026-03-07
 

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Seed.json
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Seed.json
@@ -318,6 +318,93 @@
                                     {
                                         "type": "template",
                                         "data": "Shoot Phazite (X-Ray and Nova)"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "GrappleBeamPull",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "Damage",
+                                                        "amount": 399,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 299,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "Damage",
+                                                                    "amount": 199,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/prime3/logic_database/Pirate Homeworld - Seed.txt
+++ b/randovania/games/prime3/logic_database/Pirate Homeworld - Seed.txt
@@ -44,7 +44,12 @@ Extra - asset_id: 4585599704880367469
   * Normal Door to Core Access/Door to Pirate Homeworld Leviathan Core
   * Extra - dock_index: 0
   > Event - Omega Ridley
-      Enter Hypermode and Shoot Phazite
+      All of the following:
+          Grapple Lasso and Enter Hypermode and Shoot Phazite
+          Any of the following:
+              Combat (Expert) or Damage ≥ 399
+              Combat (Intermediate) and Damage ≥ 299
+              Combat (Advanced) and Damage ≥ 199
 
 > Dock to Pirate Homeworld - Command; Heals? False
   * Layers: default


### PR DESCRIPTION
Omega Ridley previously did not require Grapple Lasso when it was needed to complete its first phase. Additionally, some basic energy requirements have been added.

Also, it seems like there was a small spacing issue in the changelog for my Bryyo Gel Refinery PR so I threw that in here.

```
      All of the following:
          Grapple Lasso and Enter Hypermode and Shoot Phazite
          Any of the following:
              Combat (Expert) or Damage ≥ 399
              Combat (Intermediate) and Damage ≥ 299
              Combat (Advanced) and Damage ≥ 199
```