### PR TITLE
Clean Up Imperial Hall Logic

### DIFF
--- a/CHANGELOG_MP3.md
+++ b/CHANGELOG_MP3.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: Gel Refinery Site: A way of scaling to the item without bombs using Space Jump and Screw Attack from the Refinery Access Door Ledge. 
 - Changed: Gel Refinery Site: Getting from the item to Gel Purification Site with just Space Jump Boots has been lowered from Intermediate to Beginner movement.
 - Changed: Imperial Hall: Getting to the opposite side of the room from both sides without moving the gel blast walls no longer requires Standable Terrain.
-- Changed: Imperial Hall: Getting the item without Grapple Lasso using Standable Terrain now always requires Movement (Intermediate).
+- Changed: Imperial Hall: Getting the item without Grapple Lasso from the bottom requires Standable Terrain (Intermediate) (Previously Beginner).
 - Added: Mogenar: Implemented basic energy and combat requirements.
 
 ##### SkyTown, Elysia

--- a/CHANGELOG_MP3.md
+++ b/CHANGELOG_MP3.md
@@ -24,9 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added: Gel Refinery Site: A way of scaling to the item without bombs using Space Jump and Screw Attack from the Refinery Access Door Ledge. 
 - Changed: Gel Refinery Site: Getting from the item to Gel Purification Site with just Space Jump Boots has been lowered from Intermediate to Beginner movement.
+- Changed: Imperial Hall: Getting to the opposite side of the room from both sides without moving the gel blast walls no longer requires Standable Terrain.
+- Changed: Imperial Hall: Getting the item without Grapple Lasso using Standable Terrain now always requires Movement (Intermediate).
 - Added: Mogenar: Implemented basic energy and combat requirements.
 
 ##### SkyTown, Elysia
+
 - Added: Helios: Implemented basic energy and combat requirements.
 
 ##### Pirate Homeworld

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -1126,26 +1126,44 @@
                                                                             "data": {
                                                                                 "type": "tricks",
                                                                                 "name": "StandableTerrain",
-                                                                                "amount": 1,
+                                                                                "amount": 2,
                                                                                 "negate": false
                                                                             }
                                                                         },
                                                                         {
                                                                             "type": "or",
                                                                             "data": {
-                                                                                "comment": null,
+                                                                                "comment": "Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE",
                                                                                 "items": [
+                                                                                    {
+                                                                                        "type": "resource",
+                                                                                        "data": {
+                                                                                            "type": "tricks",
+                                                                                            "name": "Movement",
+                                                                                            "amount": 2,
+                                                                                            "negate": false
+                                                                                        }
+                                                                                    },
                                                                                     {
                                                                                         "type": "and",
                                                                                         "data": {
-                                                                                            "comment": "Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE",
+                                                                                            "comment": null,
                                                                                             "items": [
+                                                                                                {
+                                                                                                    "type": "resource",
+                                                                                                    "data": {
+                                                                                                        "type": "items",
+                                                                                                        "name": "ScanVisor",
+                                                                                                        "amount": 1,
+                                                                                                        "negate": false
+                                                                                                    }
+                                                                                                },
                                                                                                 {
                                                                                                     "type": "resource",
                                                                                                     "data": {
                                                                                                         "type": "tricks",
                                                                                                         "name": "Movement",
-                                                                                                        "amount": 2,
+                                                                                                        "amount": 1,
                                                                                                         "negate": false
                                                                                                     }
                                                                                                 }

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.json
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.json
@@ -605,15 +605,6 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "StandableTerrain",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
                                                 }
                                             ]
                                         }
@@ -805,15 +796,6 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "StandableTerrain",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
                                                 }
                                             ]
                                         }
@@ -850,7 +832,7 @@
                         "Front of Lasso Walls": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "https://youtu.be/9FQFcMIH1vQ",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -1161,31 +1143,13 @@
                                                                                                 {
                                                                                                     "type": "resource",
                                                                                                     "data": {
-                                                                                                        "type": "items",
-                                                                                                        "name": "ScanVisor",
-                                                                                                        "amount": 1,
-                                                                                                        "negate": false
-                                                                                                    }
-                                                                                                },
-                                                                                                {
-                                                                                                    "type": "resource",
-                                                                                                    "data": {
                                                                                                         "type": "tricks",
                                                                                                         "name": "Movement",
-                                                                                                        "amount": 1,
+                                                                                                        "amount": 2,
                                                                                                         "negate": false
                                                                                                     }
                                                                                                 }
                                                                                             ]
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "resource",
-                                                                                        "data": {
-                                                                                            "type": "tricks",
-                                                                                            "name": "Movement",
-                                                                                            "amount": 2,
-                                                                                            "negate": false
                                                                                         }
                                                                                     }
                                                                                 ]

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -81,7 +81,7 @@ Extra - asset_id: 4215957264467390882
   > Door to Fiery Airdock
       Any of the following:
           After Imperial Hall Fuel Gel Walls
-          Space Jump Boots and Morph Ball and Bomb/Spring Space Jump (Beginner) and Standable Terrain (Beginner)
+          Space Jump Boots and Morph Ball and Bomb/Spring Space Jump (Beginner)
   > Morph Ball Door to Gel Cavern
       After Gel Cavern Shortcut Activated and Enabled MP3Update
   > Event - Fuel Gel Walls
@@ -104,10 +104,11 @@ Extra - asset_id: 4215957264467390882
       Any of the following:
           After Imperial Hall Fuel Gel Walls
           # https://youtu.be/9FQFcMIH1vQ
-          Space Jump Boots and Morph Ball and Bomb/Spring Space Jump (Beginner) and Standable Terrain (Beginner)
+          Space Jump Boots and Morph Ball and Bomb/Spring Space Jump (Beginner)
   > Event - Fuel Gel Walls
       Charge Beam or Plasma Beam
   > Front of Lasso Walls
+      # https://youtu.be/9FQFcMIH1vQ
       Space Jump Boots and Morph Ball and Before Imperial Hall Fuel Gel Walls and Bomb/Spring Space Jump (Beginner) and Standable Terrain (Beginner)
 
 > Morph Ball Door to Gel Cavern; Heals? False
@@ -146,10 +147,8 @@ Extra - asset_id: 4215957264467390882
                   Bomb/Spring Space Jump (Intermediate) and Use Boost Ball
                   All of the following:
                       Standable Terrain (Beginner)
-                      Any of the following:
-                          Movement (Intermediate)
-                          # Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE
-                          Scan Visor and Movement (Beginner)
+                      # Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE
+                      Movement (Intermediate)
   > Event - Grapple Lasso Walls
       Grapple Lasso
 

--- a/randovania/games/prime3/logic_database/Bryyo - Fire.txt
+++ b/randovania/games/prime3/logic_database/Bryyo - Fire.txt
@@ -146,9 +146,11 @@ Extra - asset_id: 4215957264467390882
                   After Imperial Hall Grapple Lasso Walls or Bomb/Spring Space Jump (Advanced)
                   Bomb/Spring Space Jump (Intermediate) and Use Boost Ball
                   All of the following:
-                      Standable Terrain (Beginner)
-                      # Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE
-                      Movement (Intermediate)
+                      Standable Terrain (Intermediate)
+                      Any of the following:
+                          # Jump towards the Lasso Platforms https://youtu.be/Z-XICpMJWoE
+                          Movement (Intermediate)
+                          Scan Visor and Movement (Beginner)
   > Event - Grapple Lasso Walls
       Grapple Lasso
 


### PR DESCRIPTION
- Changed: Imperial Hall: Getting to the opposite side of the room from both sides without moving the gel blast walls no longer requires Standable Terrain.
- Changed: Imperial Hall: Getting the item without Grapple Lasso using Standable Terrain now always requires Movement (Intermediate).

Additionally fixed a spacing error with the changelog and added a video to get to `Front of Lasso Walls` where one wasn't before.

The second change with buffing it to intermediate is after having it be expected in a seed and trying to do it and failing multiple times when the SSJ without boost was much easier for me, plus jumping off a seam is decently precise, so `Movement (Beginner)` felt pretty wrong.